### PR TITLE
Fix startup error with Pydantic Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+venv/
+*.pyc
+.venv*/
+.pytest_cache/

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,11 @@
+from fastapi import FastAPI
 from pydantic_settings import BaseSettings
 
+from app.api.endpoints import portfolio
+
+
 class Settings(BaseSettings):
-    """Application-wide settings pulled from environment variables or defaults."""
+    """Application-wide settings pulled from environment variables."""
 
     IBKR_HOST: str = "localhost"
     IBKR_PORT: int = 5000
@@ -13,5 +17,13 @@ class Settings(BaseSettings):
         env_file_encoding = "utf-8"
 
 
-# Single global instance imported elsewhere
 settings = Settings()
+app = FastAPI()
+
+# Include routers
+app.include_router(portfolio.router)
+
+
+@app.get("/")
+async def root():
+    return {"status": "ok"}

--- a/app/services/run_test.py
+++ b/app/services/run_test.py
@@ -1,5 +1,9 @@
+"""Utility script to manually test the IBKR service."""
+
+__test__ = False  # Prevent pytest from collecting this module
+
 import asyncio
-from ibkr_service import ibkr_service
+from .ibkr_service import ibkr_service
 
 import nest_asyncio
 nest_asyncio.apply()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests>=2.31.0
 python-dotenv>=1.0.0
 ib_async>=0.3.0
 pydantic>=1.10.13
+pydantic-settings>=2.2.1
 httpx>=0.18.2


### PR DESCRIPTION
## Summary
- implement FastAPI `app` and include portfolio router
- update service test script for relative import and to avoid pytest collection
- add `pydantic-settings` dependency
- ignore generated files and venvs

## Testing
- `pytest -q`
- `uvicorn app.main:app --host 0.0.0.0 --port 8001` *(fails if port already used)*

------
https://chatgpt.com/codex/tasks/task_e_684fd073eee8832ea9d8c2b5120accb0