### PR TITLE
Fix async usage in test

### DIFF
--- a/app/services/run_test.py
+++ b/app/services/run_test.py
@@ -10,8 +10,8 @@ nest_asyncio.apply()
 
 async def test_portfolio():
     try:
-        ibkr_service.connect()
-        portfolio = ibkr_service.fetch_portfolio_details()
+        await ibkr_service.connect()
+        portfolio = await ibkr_service.fetch_portfolio_details()
         print("Portfolio:", portfolio)
     except Exception as e:
         print("Portfolio fetch failed:", e)


### PR DESCRIPTION
## Summary
- await `ibkr_service.connect()` and `ibkr_service.fetch_portfolio_details()`
- verify script runs without runtime warnings

## Testing
- `python -m app.services.run_test`

------
https://chatgpt.com/codex/tasks/task_e_684fd93d7da0832ea2600134d1698389